### PR TITLE
Add patch for appdata versions

### DIFF
--- a/appdata_remove_mvp.patch
+++ b/appdata_remove_mvp.patch
@@ -1,0 +1,28 @@
+diff --git a/data/com.frac_tion.teleport.appdata.xml.in b/data/com.frac_tion.teleport.appdata.xml.in
+index c155015..35dd316 100644
+--- a/data/com.frac_tion.teleport.appdata.xml.in
++++ b/data/com.frac_tion.teleport.appdata.xml.in
+@@ -41,18 +41,18 @@
+   <translation type="gettext">teleport</translation>
+ 
+   <releases>
+-    <release version="MVP" date="2017-10-29">
++    <release version="0.0.1" date="2018-10-28">
+       <description>
+         <p>
+-          This basic initial version sends files chose via the file chooser or
+-          drag and drop. The Downloads directory can be set from the menu.
++          Some small fixes.
+         </p>
+       </description>
+     </release>
+-    <release version="0.0.1" date="2018-10-28">
++    <release version="0.0.0" date="2017-10-29">
+       <description>
+         <p>
+-          Some small fixes.
++          This basic initial version sends files chose via the file chooser or
++          drag and drop. The Downloads directory can be set from the menu.
+         </p>
+       </description>
+     </release>

--- a/com.frac_tion.teleport.json
+++ b/com.frac_tion.teleport.json
@@ -57,6 +57,10 @@
           },
           {
             "type": "patch",
+            "path": "appdata_remove_mvp.patch"
+          },
+          {
+            "type": "patch",
             "path": "appdata_oars.patch"
           }
         ]


### PR DESCRIPTION
Reorder versions and rename MVP to 0.0.0. A patch was sent upstream containing both patches present here.